### PR TITLE
Static and resolv.conf nameservers list

### DIFF
--- a/unix/client/dns_client_unix.ml
+++ b/unix/client/dns_client_unix.ml
@@ -55,14 +55,14 @@ module Transport : Dns_client.S
         t.nameservers <- default_resolvers ()
     in
     match read_file "/etc/resolv.conf", t.resolv_conf with
+    | Ok data, Some d ->
+      let digest = Digest.string data in
+      if Digest.equal digest d then () else decode_update data digest
+    | Ok data, None -> decode_update data (Digest.string data)
     | Error _, None -> ()
     | Error _, Some _ ->
       t.resolv_conf <- None;
       t.nameservers <- default_resolvers ()
-    | Ok data, None -> decode_update data (Digest.string data)
-    | Ok data, Some d ->
-      let digest = Digest.string data in
-      if Digest.equal digest d then () else decode_update data digest
 
   let create ?nameservers ~timeout () =
     let (protocol, nameservers), resolv_conf =


### PR DESCRIPTION
This ensures that the list of nameservers supplied by the caller is used even when resolv.conf is changed. The user is then able to override resolv.conf.

 The other commit reorders some match cases in `Dns_client_unix.maybe_resolv_conf` so they match the order in `Dns_client_lwt.maybe_resolv_conf`